### PR TITLE
Add banner and page for jet vane project

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
     <p>
       I developed a jet vane thrust vectoring mechanism to steer a high-power solid rocket using servo-actuated carbon-fiber vanes positioned in the exhaust stream. The system allows for directional control during vertical ascent, and includes aerodynamic and thermal shielding considerations for high-temperature plume exposure.
     </p>
-    <a class="read-more" href="rocket-jet-vane.pdf" target="_blank">Read More →</a>
+    <a class="read-more" href="rocket-jet-vane.html">Read More →</a>
   </div>
 
     <!-- 3D-Printed Rotatable Amp Stand -->

--- a/rocket-jet-vane.html
+++ b/rocket-jet-vane.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Jet Vane Thrust Vector Control</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+    }
+
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+
+    nav a.active {
+      color: #fff;
+      font-weight: 600;
+    }
+
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+
+    main {
+      max-width: 800px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+
+    a {
+      color: #007bff;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+      margin: 1em 0;
+    }
+
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+
+    h1 {
+      margin-bottom: 0.4em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+
+  <main>
+    <h1>Jet Vane Thrust Vector Control for High-Power Rocketry</h1>
+    <p>
+      I developed a jet vane thrust vectoring mechanism to steer a high-power solid rocket using servo-actuated carbon-fiber vanes positioned in the exhaust stream. The system allows for directional control during vertical ascent and includes aerodynamic and thermal shielding considerations for high-temperature plume exposure.
+    </p>
+    <img src="rocket-jet-vane.png" alt="Rocket jet vane mechanism" />
+    <p>
+      <a href="rocket-jet-vane.pdf" target="_blank">View the detailed PDF report</a>
+    </p>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated Jet Vane project page with same navigation banner as other pages
- Link Jet Vane project card on homepage to the new page

## Testing
- `npx htmlhint index.html amp-stand.html exoskeleton.html rocket-jet-vane.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_6891669ee584832eaba0f8ed59d54de2