### PR TITLE
Remove Read More buttons from small product cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,24 +128,10 @@
 }
 
 .mini-card p {
-  margin: 0 0 0.75em 0;
+  margin: 0;
   font-size: 0.95em;
 }
 
-.mini-card .read-more {
-  display: inline-block;
-  background-color: #007bff;
-  color: white;
-  padding: 0.4em 0.8em;
-  border-radius: 4px;
-  text-decoration: none;
-  font-weight: 500;
-}
-
-.mini-card .read-more:hover {
-  background-color: #0056b3;
-}
-    
   </style>
 </head>
 <body>
@@ -209,7 +195,6 @@
       <img src="phone-stand.png" alt="3D printed phone stand" class="thumb" />
       <h4>Compact 3D‑Printed Phone Stand</h4>
       <p>Pocketable, two-angle stand with cable pass-through and stable base.</p>
-      <a class="read-more" href="phone-stand.html">Read More →</a>
     </div>
 
     <!-- Katana Holder -->
@@ -217,7 +202,6 @@
       <img src="katana-holder.png" alt="3D printed katana holder" class="thumb" />
       <h4>Wall‑Mounted Katana Holder</h4>
       <p>Parametric mounts with felt-lined saddles and concealed fasteners.</p>
-      <a class="read-more" href="katana-holder.html">Read More →</a>
     </div>
 
     <!-- Perfume Mat & Holder -->
@@ -225,7 +209,6 @@
       <img src="perfume-mat-holder.png" alt="Perfume mat and holder" class="thumb" />
       <h4>Perfume Mat & Display Holder</h4>
       <p>Non-slip tray with modular bottle docks and drip containment lip.</p>
-      <a class="read-more" href="perfume-mat-holder.html">Read More →</a>
     </div>
 
     <!-- Pill Bottle with Threaded Cap -->
@@ -233,7 +216,6 @@
       <img src="pill-bottle.png" alt="3D printed pill bottle" class="thumb" />
       <h4>Pill Bottle with Threaded Cap</h4>
       <p>Print‑in‑place threads, knurled cap, and gasket groove for sealing.</p>
-      <a class="read-more" href="pill-bottle.html">Read More →</a>
     </div>
 
     <!-- iPhone Wall Mount -->
@@ -241,7 +223,6 @@
       <img src="iphone-wall-mount.png" alt="iPhone wall mount" class="thumb" />
       <h4>iPhone Wall Mount (Video Calling)</h4>
       <p>Orientation‑locking mount with soft inserts and hidden cable routing.</p>
-      <a class="read-more" href="iphone-wall-mount.html">Read More →</a>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary
- drop "Read More" links from Industrial & Product Design mini cards so each item shows just an image, title, and description
- tidy up styles for mini cards by removing unused read-more styling and trimming paragraph margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689167dea490832e8f85b53e35db8b01