### PR TITLE
Add image galleries and pages for small projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,37 +192,42 @@
   <div class="mini-grid">
     <!-- Phone Stand -->
     <div class="mini-card">
-      <img src="phone-stand.png" alt="3D printed phone stand" class="thumb" />
+      <img src="phonestand.png" alt="CAD model of phone stand" class="thumb" />
       <h4>Compact 3D‑Printed Phone Stand</h4>
       <p>Pocketable, two-angle stand with cable pass-through and stable base.</p>
+      <a class="read-more" href="phone-stand.html">Read More →</a>
     </div>
 
     <!-- Katana Holder -->
     <div class="mini-card">
-      <img src="katana-holder.png" alt="3D printed katana holder" class="thumb" />
+      <img src="katana.png" alt="CAD model of katana holder" class="thumb" />
       <h4>Wall‑Mounted Katana Holder</h4>
       <p>Parametric mounts with felt-lined saddles and concealed fasteners.</p>
+      <a class="read-more" href="katana-holder.html">Read More →</a>
     </div>
 
     <!-- Perfume Mat & Holder -->
     <div class="mini-card">
-      <img src="perfume-mat-holder.png" alt="Perfume mat and holder" class="thumb" />
+      <img src="perfume.png" alt="CAD model of perfume mat" class="thumb" />
       <h4>Perfume Mat & Display Holder</h4>
       <p>Non-slip tray with modular bottle docks and drip containment lip.</p>
+      <a class="read-more" href="perfume-mat-holder.html">Read More →</a>
     </div>
 
     <!-- Pill Bottle with Threaded Cap -->
     <div class="mini-card">
-      <img src="pill-bottle.png" alt="3D printed pill bottle" class="thumb" />
+      <img src="bottle.png" alt="CAD model of pill bottle" class="thumb" />
       <h4>Pill Bottle with Threaded Cap</h4>
       <p>Print‑in‑place threads, knurled cap, and gasket groove for sealing.</p>
+      <a class="read-more" href="pill-bottle.html">Read More →</a>
     </div>
 
     <!-- iPhone Wall Mount -->
     <div class="mini-card">
-      <img src="iphone-wall-mount.png" alt="iPhone wall mount" class="thumb" />
+      <img src="wallmount.png" alt="CAD model of iPhone wall mount" class="thumb" />
       <h4>iPhone Wall Mount (Video Calling)</h4>
       <p>Orientation‑locking mount with soft inserts and hidden cable routing.</p>
+      <a class="read-more" href="iphone-wall-mount.html">Read More →</a>
     </div>
   </div>
   

--- a/iphone-wall-mount.html
+++ b/iphone-wall-mount.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>iPhone Wall Mount</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+      background: linear-gradient(#fafafa, #eaeaea);
+    }
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+    main {
+      max-width: 900px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+    header.hero {
+      text-align: center;
+      padding: 2em 1em 3em;
+      background: linear-gradient(135deg, #e3f2fd, #f5f5f5);
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      margin-bottom: 2em;
+    }
+    .hero img {
+      max-width: 300px;
+      width: 80%;
+      height: auto;
+      margin: 0 auto 1em;
+      display: block;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+      gap: 1.5em;
+      margin: 2em 0;
+    }
+    .gallery-grid figure {
+      margin: 0;
+      background: #fff;
+      padding: 1em;
+      border-radius: 6px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .gallery-grid figcaption {
+      font-size: 0.9em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+  <main>
+    <header class="hero">
+      <img src="wallmount.png" alt="CAD model of iPhone wall mount" />
+      <h1>iPhone Wall Mount</h1>
+    </header>
+    <section class="gallery">
+      <h2>Gallery</h2>
+      <div class="gallery-grid">
+        <figure>
+          <img src="wallmount1.png" alt="Wall mount installed without phone" />
+          <figcaption>Mount secured to the wall awaiting a phone.</figcaption>
+        </figure>
+        <figure>
+          <img src="wallmount2.png" alt="Wall mount holding phone with charging cable" />
+          <figcaption>iPhone docked and charging in the wall mount.</figcaption>
+        </figure>
+      </div>
+    </section>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>

--- a/katana-holder.html
+++ b/katana-holder.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wall‑Mounted Katana Holder</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+      background: linear-gradient(#fafafa, #eaeaea);
+    }
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+    main {
+      max-width: 900px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+    header.hero {
+      text-align: center;
+      padding: 2em 1em 3em;
+      background: linear-gradient(135deg, #e3f2fd, #f5f5f5);
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      margin-bottom: 2em;
+    }
+    .hero img {
+      max-width: 300px;
+      width: 80%;
+      height: auto;
+      margin: 0 auto 1em;
+      display: block;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+      gap: 1.5em;
+      margin: 2em 0;
+    }
+    .gallery-grid figure {
+      margin: 0;
+      background: #fff;
+      padding: 1em;
+      border-radius: 6px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .gallery-grid figcaption {
+      font-size: 0.9em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+  <main>
+    <header class="hero">
+      <img src="katana.png" alt="CAD model of katana holder" />
+      <h1>Wall‑Mounted Katana Holder</h1>
+    </header>
+    <section class="gallery">
+      <h2>Gallery</h2>
+      <div class="gallery-grid">
+        <figure>
+          <img src="katana1.png" alt="Katana holder mounted without katana" />
+          <figcaption>Holder installed on the wall awaiting the blade.</figcaption>
+        </figure>
+        <figure>
+          <img src="katana2.png" alt="Katana resting in holder" />
+          <figcaption>Katana displayed on the mounted holder.</figcaption>
+        </figure>
+      </div>
+    </section>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>

--- a/perfume-mat-holder.html
+++ b/perfume-mat-holder.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Perfume Mat & Display Holder</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+      background: linear-gradient(#fafafa, #eaeaea);
+    }
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+    main {
+      max-width: 900px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+    header.hero {
+      text-align: center;
+      padding: 2em 1em 3em;
+      background: linear-gradient(135deg, #e3f2fd, #f5f5f5);
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      margin-bottom: 2em;
+    }
+    .hero img {
+      max-width: 300px;
+      width: 80%;
+      height: auto;
+      margin: 0 auto 1em;
+      display: block;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+      gap: 1.5em;
+      margin: 2em 0;
+    }
+    .gallery-grid figure {
+      margin: 0;
+      background: #fff;
+      padding: 1em;
+      border-radius: 6px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .gallery-grid figcaption {
+      font-size: 0.9em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+  <main>
+    <header class="hero">
+      <img src="perfume.png" alt="CAD model of perfume mat" />
+      <h1>Perfume Mat & Display Holder</h1>
+    </header>
+    <section class="gallery">
+      <h2>Gallery</h2>
+      <div class="gallery-grid">
+        <figure>
+          <img src="perfume1.png" alt="Perfume mat in real life" />
+          <figcaption>Printed mat ready for organizing perfume bottles.</figcaption>
+        </figure>
+        <figure>
+          <img src="perfume2.png" alt="Perfume mat loaded with perfumes" />
+          <figcaption>Display holder showcasing a full perfume collection.</figcaption>
+        </figure>
+      </div>
+    </section>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>

--- a/phone-stand.html
+++ b/phone-stand.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Compact 3D‑Printed Phone Stand</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+      background: linear-gradient(#fafafa, #eaeaea);
+    }
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+    main {
+      max-width: 900px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+    header.hero {
+      text-align: center;
+      padding: 2em 1em 3em;
+      background: linear-gradient(135deg, #e3f2fd, #f5f5f5);
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      margin-bottom: 2em;
+    }
+    .hero img {
+      max-width: 300px;
+      width: 80%;
+      height: auto;
+      margin: 0 auto 1em;
+      display: block;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    }
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+      gap: 1.5em;
+      margin: 2em 0;
+    }
+    .gallery-grid figure {
+      margin: 0;
+      background: #fff;
+      padding: 1em;
+      border-radius: 6px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .gallery-grid figcaption {
+      font-size: 0.9em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+  <main>
+    <header class="hero">
+      <img src="phonestand.png" alt="CAD model of phone stand" />
+      <h1>Compact 3D‑Printed Phone Stand</h1>
+    </header>
+    <section class="gallery">
+      <h2>Gallery</h2>
+      <div class="gallery-grid">
+        <figure>
+          <img src="phonestand1.png" alt="Phone stand in use with charging cable" />
+          <figcaption>Printed stand supporting a phone while routing the charging cable.</figcaption>
+        </figure>
+      </div>
+    </section>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>

--- a/pill-bottle.html
+++ b/pill-bottle.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pill Bottle with Threaded Cap</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      line-height: 1.6;
+      color: #222;
+      background: linear-gradient(#fafafa, #eaeaea);
+    }
+    nav {
+      background: #2f343a;
+      padding: 1em;
+      text-align: center;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+    }
+    nav a {
+      margin: 0 1em;
+      text-decoration: none;
+      color: #aaa;
+      font-weight: 400;
+      transition: color 0.2s ease;
+    }
+    nav a:hover {
+      color: #fff;
+      text-decoration: none;
+    }
+    main {
+      max-width: 900px;
+      margin: 2em auto;
+      padding: 1em;
+    }
+    header.hero {
+      text-align: center;
+      padding: 2em 1em 3em;
+      background: linear-gradient(135deg, #e3f2fd, #f5f5f5);
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      margin-bottom: 2em;
+    }
+    .hero img {
+      max-width: 300px;
+      width: 80%;
+      height: auto;
+      margin: 0 auto 1em;
+      display: block;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    }
+    img, video {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px,1fr));
+      gap: 1.5em;
+      margin: 2em 0;
+    }
+    .gallery-grid figure {
+      margin: 0;
+      background: #fff;
+      padding: 1em;
+      border-radius: 6px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .gallery-grid figcaption {
+      font-size: 0.9em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
+  </nav>
+  <main>
+    <header class="hero">
+      <img src="bottle.png" alt="CAD model of pill bottle" />
+      <h1>Pill Bottle with Threaded Cap</h1>
+    </header>
+    <section class="gallery">
+      <h2>Gallery</h2>
+      <div class="gallery-grid">
+        <figure>
+          <img src="cap.png" alt="CAD model of threaded cap" />
+          <figcaption>Knurled cap with print-in-place threads.</figcaption>
+        </figure>
+        <figure>
+          <video controls src="threadcap.mov"></video>
+          <figcaption>Fastening the cap onto the printed bottle.</figcaption>
+        </figure>
+      </div>
+    </section>
+    <a class="back" href="index.html">← Back to portfolio</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link thumbnails in the Industrial & Product Design section to dedicated project pages.
- add new pages showcasing the phone stand, katana holder, perfume mat, pill bottle, and iPhone wall mount, each with image galleries; pill bottle page also embeds a video of the threaded cap in .mov format.
- correct the pill bottle page to reference `threadcap.mov` instead of `threadcap.mp4`.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892304a6d64832eafe61f0e6799ae09