### PR TITLE
Expand product design grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 
     /* Industrial & Product Design section */
     .ipd-section {
-      background: #f5f5f5;
+      background: linear-gradient(135deg, #ffa751, #ffe259);
       padding: 2em 1em;
       border-radius: 8px;
       margin-top: 3em;
@@ -114,29 +114,36 @@
     /* Project grid for small items */
     .mini-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 1.5em;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 2em;
       margin-top: 1.5em;
     }
 
+    @media (max-width: 600px) {
+      .mini-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
     .mini-card {
-      border: 1px solid #e0e0e0;
+      border: 2px solid #e0e0e0;
       border-radius: 8px;
       background: #fff;
       padding: 1em;
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
       text-align: center;
     }
 
     .mini-card:hover {
-      transform: translateY(-4px);
+      transform: translateY(-4px) scale(1.02);
       box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+      border-color: #ff6a00;
     }
 
     .mini-card .thumb {
       width: 100%;
-      height: 150px;
+      height: 220px;
       object-fit: contain;
       border-radius: 4px;
       margin-bottom: 0.75em;
@@ -145,12 +152,12 @@
 
     .mini-card h4 {
       margin: 0 0 0.25em 0;
-      font-size: 1.05em;
+      font-size: 1.2em;
     }
 
     .mini-card p {
       margin: 0;
-      font-size: 0.95em;
+      font-size: 1.05em;
     }
 
   </style>


### PR DESCRIPTION
## Summary
- Show industrial & product design items in two-column grid
- Increase image size and typography for product cards
- Add vibrant gradient and hover accents for a more exciting look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925f4cf6ac832eb3fae0b664e89b01