### PR TITLE
Fix phone stand images on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
     <div class="mini-grid">
       <div class="mini-card">
         <div class="thumb-row">
-          <img class="thumb" src="phonestand1.png" alt="Phone Stand">
-          <img class="thumb" src="phonestand2.png" alt="Phone Stand">
+          <img class="thumb" src="phonestand.png" alt="Phone Stand CAD">
+          <img class="thumb" src="phonestand1.png" alt="Phone Stand Photo">
         </div>
         <strong>Compact Phone Stand</strong>
         <p>Pocket-sized stand with two-angle support and cable cutout.</p>


### PR DESCRIPTION
## Summary
- Correct broken phone stand thumbnails on homepage by using existing file names and clearer alt text.

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892b02943c8832e9176c9d12b6431de