### PR TITLE
Refine project and product images

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,253 +1,321 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>William Nagassar | Portfolio</title>
-  <link rel="icon" href="favicon.ico" type="image/x-icon">
-  <style>
-    :root {
-      --accent: #1a237e;
-      --bg-light: #f4f6f8;
-      --bg-dark: #2f343a;
-      --text-primary: #222;
-      --text-muted: #666;
-    }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>William Nagassar | Portfolio</title>
+    <link rel="icon" href="favicon.ico" type="image/x-icon" />
+    <style>
+      :root {
+        --accent: #1a237e;
+        --bg-light: #f4f6f8;
+        --bg-dark: #2f343a;
+        --text-primary: #222;
+        --text-muted: #666;
+      }
 
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      margin: 0;
-      padding: 0;
-      background: var(--bg-light);
-      color: var(--text-primary);
-      line-height: 1.6;
-    }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+        margin: 0;
+        padding: 0;
+        background: var(--bg-light);
+        color: var(--text-primary);
+        line-height: 1.6;
+      }
 
-    nav {
-      background: var(--bg-dark);
-      padding: 1em;
-      text-align: center;
-      position: sticky;
-      top: 0;
-      z-index: 1000;
-    }
+      nav {
+        background: var(--bg-dark);
+        padding: 1em;
+        text-align: center;
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+      }
 
-    nav a {
-      margin: 0 1em;
-      text-decoration: none;
-      color: #aaa;
-      font-weight: 500;
-      transition: color 0.2s ease;
-    }
+      nav a {
+        margin: 0 1em;
+        text-decoration: none;
+        color: #aaa;
+        font-weight: 500;
+        transition: color 0.2s ease;
+      }
 
-    nav a:hover,
-    nav a.active {
-      color: #fff;
-    }
+      nav a:hover,
+      nav a.active {
+        color: #fff;
+      }
 
-    header {
-      text-align: center;
-      padding: 3em 1em 2em;
-      background-color: white;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-    }
+      header {
+        text-align: center;
+        padding: 3em 1em 2em;
+        background-color: white;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+      }
 
-    header h1 {
-      font-size: 2em;
-      margin-bottom: 0.25em;
-    }
+      header h1 {
+        font-size: 2em;
+        margin-bottom: 0.25em;
+      }
 
-    section {
-      max-width: 900px;
-      margin: 2em auto;
-      padding: 0 1em;
-    }
+      section {
+        max-width: 900px;
+        margin: 2em auto;
+        padding: 0 1em;
+      }
 
-    h2 {
-      font-size: 1.6em;
-      border-bottom: 2px solid var(--accent);
-      padding-bottom: 0.3em;
-      margin-bottom: 1em;
-    }
+      h2 {
+        font-size: 1.6em;
+        border-bottom: 2px solid var(--accent);
+        padding-bottom: 0.3em;
+        margin-bottom: 1em;
+      }
 
-    .project-card {
-      background: white;
-      border-radius: 8px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.05);
-      margin-bottom: 2em;
-      overflow: hidden;
-    }
+      .project-card {
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+        margin-bottom: 2em;
+        overflow: hidden;
+      }
 
-    .project-image {
-      width: 100%;
-      height: auto;
-      max-height: 280px;
-      object-fit: cover;
-    }
+      .project-image {
+        width: 100%;
+        height: 200px;
+        object-fit: contain;
+      }
 
-    .project-content {
-      padding: 1.5em;
-    }
+      .project-content {
+        padding: 1.5em;
+      }
 
-    .project-card h3 {
-      margin-top: 0;
-      color: var(--accent);
-    }
+      .project-card h3 {
+        margin-top: 0;
+        color: var(--accent);
+      }
 
-    .read-more {
-      display: inline-block;
-      margin-top: 1em;
-      background: var(--accent);
-      color: white;
-      padding: 0.5em 1em;
-      border-radius: 4px;
-      text-decoration: none;
-      font-weight: 500;
-      transition: background 0.3s ease;
-    }
+      .read-more {
+        display: inline-block;
+        margin-top: 1em;
+        background: var(--accent);
+        color: white;
+        padding: 0.5em 1em;
+        border-radius: 4px;
+        text-decoration: none;
+        font-weight: 500;
+        transition: background 0.3s ease;
+      }
 
-    .read-more:hover {
-      background: #0d133d;
-    }
+      .read-more:hover {
+        background: #0d133d;
+      }
 
-    .mini-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 2em;
-      margin-top: 1.5em;
-    }
+      .mini-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 2em;
+        margin-top: 1.5em;
+      }
 
-    .mini-card {
-      background: white;
-      border-radius: 6px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-      padding: 1em;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      text-align: center;
-    }
+      .mini-card {
+        background: white;
+        border-radius: 6px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+        padding: 1em;
+        transition:
+          transform 0.2s ease,
+          box-shadow 0.2s ease;
+        text-align: center;
+      }
 
-    .mini-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
-    }
+      .mini-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
+      }
 
-    .thumb-row {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.75em;
-      margin-bottom: 1em;
-    }
+      .thumb-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.75em;
+        margin-bottom: 1em;
+      }
 
-    .thumb {
-      width: 140px;
-      height: 140px;
-      object-fit: cover;
-      border-radius: 4px;
-      background: #e0e0e0;
-    }
-  </style>
-</head>
-<body>
-  <nav>
-    <a href="#home" class="active">Home</a>
-    <a href="#projects">Projects</a>
-    <a href="https://www.linkedin.com/in/william-nagassar-903395218/" target="_blank">LinkedIn</a>
-  </nav>
+      .thumb-row.three {
+        display: grid;
+        grid-template-columns: repeat(2, 140px);
+        justify-content: center;
+        gap: 0.75em;
+      }
 
-  <header>
-    <h1>William Nagassar</h1>
-    <p>Mechanical Engineering Student | CAD, Aerospace & Prototyping</p>
-  </header>
+      .thumb-row.three .thumb:nth-child(1) {
+        grid-column: 1 / span 2;
+        justify-self: center;
+      }
 
-  <section id="home">
-    <h2>About Me</h2>
-    <p>I’m a mechanical engineering student focused on design, prototyping, and aerospace systems. My work spans CAD modeling, high-performance 3D printing, and cross-functional team projects.</p>
-  </section>
+      .thumb {
+        width: 140px;
+        height: 140px;
+        object-fit: contain;
+        border-radius: 4px;
+        background: none;
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a href="#home" class="active">Home</a>
+      <a href="#projects">Projects</a>
+      <a
+        href="https://www.linkedin.com/in/william-nagassar-903395218/"
+        target="_blank"
+        >LinkedIn</a
+      >
+    </nav>
 
-  <section id="projects">
-    <h2>Projects</h2>
+    <header>
+      <h1>William Nagassar</h1>
+      <p>Mechanical Engineering Student | CAD, Aerospace & Prototyping</p>
+    </header>
 
-    <div class="project-card">
-      <img src="exoskeleton-project.png" alt="Exoskeleton overview" class="project-image" />
-      <div class="project-content">
-        <h3>Syringe-Actuated Exoskeleton Arm</h3>
-        <p>Led the design of a motorless exoskeleton arm using syringes and elastic return for assistive motion. Integrated mechanical advantage and 3D-printed joints for lightweight efficiency.</p>
-        <a class="read-more" href="exoskeleton.html">Read More →</a>
-      </div>
-    </div>
+    <section id="home">
+      <h2>About Me</h2>
+      <p>
+        I’m a mechanical engineering student focused on design, prototyping, and
+        aerospace systems. My work spans CAD modeling, high-performance 3D
+        printing, and cross-functional team projects.
+      </p>
+    </section>
 
-    <div class="project-card">
-      <img src="rocket-jet-vane.png" alt="Jet vane rocket" class="project-image" />
-      <div class="project-content">
-        <h3>Jet Vane TVC System for Rockets</h3>
-        <p>Developed a carbon-fiber jet vane mechanism for solid rocket vector control. Integrated servo actuation and thermal shielding for high-power ascent correction.</p>
-        <a class="read-more" href="rocket-jet-vane.html">Read More →</a>
-      </div>
-    </div>
+    <section id="projects">
+      <h2>Projects</h2>
 
-    <div class="project-card">
-      <img src="ampcad.png" alt="Amp stand render" class="project-image" />
-      <div class="project-content">
-        <h3>3D‑Printed Rotatable Amp Stand</h3>
-        <p>Compact stand for elevating a 12 lb guitar amp. Designed for strength, print efficiency, and aesthetics with low-profile pivot and non-slip feet.</p>
-        <a class="read-more" href="amp-stand.html">Read More →</a>
-      </div>
-    </div>
-
-    <h2 style="margin-top: 3em">Product & Accessory Designs</h2>
-    <div class="mini-grid">
-      <!-- Phone Stand -->
-      <div class="mini-card">
-        <div class="thumb-row">
-          <img src="phonestand.png" class="thumb" alt="Phone stand 1">
-          <img src="phonestand1.png" class="thumb" alt="Phone stand 2">
+      <div class="project-card">
+        <img
+          src="exoskeleton-project.png"
+          alt="Exoskeleton overview"
+          class="project-image"
+        />
+        <div class="project-content">
+          <h3>Syringe-Actuated Exoskeleton Arm</h3>
+          <p>
+            Led the design of a motorless exoskeleton arm using syringes and
+            elastic return for assistive motion. Integrated mechanical advantage
+            and 3D-printed joints for lightweight efficiency.
+          </p>
+          <a class="read-more" href="exoskeleton.html">Read More →</a>
         </div>
-        <h4>Compact Phone Stand</h4>
-        <p>Pocket-sized stand with two-angle support and cable cutout.</p>
       </div>
 
-      <!-- Katana Holder -->
-      <div class="mini-card">
-        <div class="thumb-row">
-          <img src="katana.png" class="thumb" alt="Katana holder 1">
-          <img src="katana1.png" class="thumb" alt="Katana holder 2">
+      <div class="project-card">
+        <img
+          src="rocket-jet-vane.png"
+          alt="Jet vane rocket"
+          class="project-image"
+        />
+        <div class="project-content">
+          <h3>Jet Vane TVC System for Rockets</h3>
+          <p>
+            Developed a carbon-fiber jet vane mechanism for solid rocket vector
+            control. Integrated servo actuation and thermal shielding for
+            high-power ascent correction.
+          </p>
+          <a class="read-more" href="rocket-jet-vane.html">Read More →</a>
         </div>
-        <h4>Wall-Mounted Katana Holder</h4>
-        <p>Felt-lined supports with parametric fasteners and hidden anchors.</p>
       </div>
 
-      <!-- Perfume Holder -->
-      <div class="mini-card">
-        <div class="thumb-row">
-          <img src="perfume.png" class="thumb" alt="Perfume 1">
-          <img src="perfume1.png" class="thumb" alt="Perfume 2">
+      <div class="project-card">
+        <img src="ampcad.png" alt="Amp stand render" class="project-image" />
+        <div class="project-content">
+          <h3>3D‑Printed Rotatable Amp Stand</h3>
+          <p>
+            Compact stand for elevating a 12 lb guitar amp. Designed for
+            strength, print efficiency, and aesthetics with low-profile pivot
+            and non-slip feet.
+          </p>
+          <a class="read-more" href="amp-stand.html">Read More →</a>
         </div>
-        <h4>Perfume Mat & Display</h4>
-        <p>Slip-proof tray with modular holders and integrated drainage lip.</p>
       </div>
 
-      <!-- Pill Bottle -->
-      <div class="mini-card">
-        <div class="thumb-row">
-          <img src="bottle.png" class="thumb" alt="Bottle">
-          <img src="cap.png" class="thumb" alt="Cap">
-          <video src="threadcap.mov" class="thumb" autoplay muted loop playsinline oncontextmenu="return false;" controlsList="nodownload"></video>
+      <h2 style="margin-top: 3em">Product & Accessory Designs</h2>
+      <div class="mini-grid">
+        <!-- Phone Stand -->
+        <div class="mini-card">
+          <div class="thumb-row">
+            <img src="phonestand.png" class="thumb" alt="Phone stand 1" />
+            <img src="phonestand1.png" class="thumb" alt="Phone stand 2" />
+          </div>
+          <h4>Compact Phone Stand</h4>
+          <p>Pocket-sized stand with two-angle support and cable cutout.</p>
         </div>
-        <h4>Threaded Pill Bottle</h4>
-        <p>Knurled cap, gasket groove, print-in-place threads.</p>
-      </div>
 
-      <!-- Wall Mount -->
-      <div class="mini-card">
-        <div class="thumb-row">
-          <img src="wallmount.png" class="thumb" alt="Wall mount 1">
-          <img src="wallmount1.png" class="thumb" alt="Wall mount 2">
+        <!-- Katana Holder -->
+        <div class="mini-card">
+          <div class="thumb-row three">
+            <img src="katana.png" class="thumb" alt="Katana holder 1" />
+            <img src="katana1.png" class="thumb" alt="Katana holder 2" />
+            <img src="katana2.png" class="thumb" alt="Katana holder 3" />
+          </div>
+          <h4>Wall-Mounted Katana Holder</h4>
+          <p>
+            Felt-lined supports with parametric fasteners and hidden anchors.
+          </p>
         </div>
-        <h4>iPhone Wall Mount</h4>
-        <p>Secure mount for video calling with cable routing & locking tab.</p>
+
+        <!-- Perfume Holder -->
+        <div class="mini-card">
+          <div class="thumb-row three">
+            <img src="perfume.png" class="thumb" alt="Perfume 1" />
+            <img src="perfume1.png" class="thumb" alt="Perfume 2" />
+            <img src="perfume2.png" class="thumb" alt="Perfume 3" />
+          </div>
+          <h4>Perfume Mat & Display</h4>
+          <p>
+            Slip-proof tray with modular holders and integrated drainage lip.
+          </p>
+        </div>
+
+        <!-- Perfume Cap -->
+        <div class="mini-card">
+          <div class="thumb-row">
+            <img src="cap.png" class="thumb" alt="Perfume cap" />
+          </div>
+          <h4>Perfume Cap</h4>
+          <p>Snap-fit cap designed to pair with custom perfume displays.</p>
+        </div>
+
+        <!-- Pill Bottle -->
+        <div class="mini-card">
+          <div class="thumb-row">
+            <img src="bottle.png" class="thumb" alt="Bottle" />
+            <img src="cap.png" class="thumb" alt="Cap" />
+            <video
+              src="threadcap.mov"
+              class="thumb"
+              autoplay
+              muted
+              loop
+              playsinline
+              oncontextmenu="return false;"
+              controlsList="nodownload"
+            ></video>
+          </div>
+          <h4>Threaded Pill Bottle</h4>
+          <p>Knurled cap, gasket groove, print-in-place threads.</p>
+        </div>
+
+        <!-- Wall Mount -->
+        <div class="mini-card">
+          <div class="thumb-row three">
+            <img src="wallmount.png" class="thumb" alt="Wall mount 1" />
+            <img src="wallmount1.png" class="thumb" alt="Wall mount 2" />
+            <img src="wallmount2.png" class="thumb" alt="Wall mount 3" />
+          </div>
+          <h4>iPhone Wall Mount</h4>
+          <p>
+            Secure mount for video calling with cable routing & locking tab.
+          </p>
+        </div>
       </div>
-    </div>
-  </section>
-</body>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- shrink project thumbnails and show full images
- remove product thumbnail cropping/grey backgrounds and support triangular layout for three images
- add a new perfume cap product entry

## Testing
- `npx prettier --check index.html`


------
https://chatgpt.com/codex/tasks/task_e_6892b9c94d34832e9eaa5a52a3823933