### PR TITLE
Link project read-more buttons to PDFs

### DIFF
--- a/hotairballoon.pdf
+++ b/hotairballoon.pdf
@@ -1,0 +1,20 @@
+%PDF-1.1
+1 0 obj <</Type /Catalog /Pages 2 0 R>> endobj
+2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>> endobj
+3 0 obj <</Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources <</Font <</F1 5 0 R>>>>>> endobj
+4 0 obj <</Length 44>> stream
+BT /F1 24 Tf 100 100 Td (Hot Air Balloon) Tj ET
+endstream endobj
+5 0 obj <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>> endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000230 00000 n 
+0000000335 00000 n 
+trailer <</Size 6 /Root 1 0 R>>
+startxref
+421
+%%EOF

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
             I led a team of 5 to analyze and design a landing gear mechanism for our final project in a mechanical design course.
             I contributed to developing the initial simulation in Working Model and later performed detailed kinematic analysis and component design using SolidWorks.
           </p>
-          <a class="read-more" href="landing-gear-design.html">Read More →</a>
+          <a class="read-more" href="landinggear.pdf">Read More →</a>
         </div>
       </div>
 
@@ -269,7 +269,7 @@
             related to center of gravity, buoyant force, weight distribution, and vertical acceleration to assess
             stability and lift performance.
           </p>
-          <a class="read-more" href="hot-air-balloon.html">Read More →</a>
+          <a class="read-more" href="hotairballoon.pdf">Read More →</a>
         </div>
       </div>
 
@@ -286,7 +286,7 @@
             As part of a materials science course final project, I evaluated candidate materials for high-temperature turbine 
             blades used in jet engines, balancing factors such as creep resistance, mechanical strength, and manufacturability.
           </p>
-          <a class="read-more" href="turbine-blade-selection.html">Read More →</a>
+          <a class="read-more" href="jetengine.pdf">Read More →</a>
         </div>
       </div>
 

--- a/jetengine.pdf
+++ b/jetengine.pdf
@@ -1,0 +1,20 @@
+%PDF-1.1
+1 0 obj <</Type /Catalog /Pages 2 0 R>> endobj
+2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>> endobj
+3 0 obj <</Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources <</Font <</F1 5 0 R>>>>>> endobj
+4 0 obj <</Length 44>> stream
+BT /F1 24 Tf 100 100 Td (Jet Engine Blade) Tj ET
+endstream endobj
+5 0 obj <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>> endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000230 00000 n 
+0000000335 00000 n 
+trailer <</Size 6 /Root 1 0 R>>
+startxref
+421
+%%EOF

--- a/landinggear.pdf
+++ b/landinggear.pdf
@@ -1,0 +1,20 @@
+%PDF-1.1
+1 0 obj <</Type /Catalog /Pages 2 0 R>> endobj
+2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>> endobj
+3 0 obj <</Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources <</Font <</F1 5 0 R>>>>>> endobj
+4 0 obj <</Length 44>> stream
+BT /F1 24 Tf 100 100 Td (Landing Gear) Tj ET
+endstream endobj
+5 0 obj <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>> endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000230 00000 n 
+0000000335 00000 n 
+trailer <</Size 6 /Root 1 0 R>>
+startxref
+421
+%%EOF


### PR DESCRIPTION
## Summary
- Update landing gear, hot air balloon, and jet engine turbine blade project cards so their "Read More" buttons open corresponding PDF documents.
- Include placeholder PDFs for the updated links.

## Testing
- `npm test` *(fails: ENOENT no package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6892fe580ad0832e96767f30bd7f7b87